### PR TITLE
fix: replace tsed.io by tsed.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -14,11 +14,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/tutorials/prisma.html">Tutorial</a>
+  <a href="https://tsed.dev/tutorials/prisma.html">Tutorial</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://slack.tsed.dev">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>
@@ -33,11 +33,11 @@ Dedicated repository for Formio front-end related packages.
 - Provide a better TypeScript support,
 - Provide a [@tsed/tailwind-formio](./packages/tailwind-formio/readme.md) package to support tailwind CSS framework with formio.
 - Provide a lightweight redux utils packages.
-- Provide a [storybook](https://formio.tsed.io)
+- Provide a [storybook](https://formio.tsed.dev)
 
 ## Documentation
 
-Documentation is available on [https://formio.tsed.io](https://formio.tsed.io).
+Documentation is available on [https://formio.tsed.dev](https://formio.tsed.dev).
 
 ## Projects examples
 

--- a/packages/react-formio-container/readme.md
+++ b/packages/react-formio-container/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -14,11 +14,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/tutorials/prisma.html">Tutorial</a>
+  <a href="https://tsed.dev/tutorials/prisma.html">Tutorial</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://slack.tsed.dev">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>
@@ -29,7 +29,7 @@ A [React](http://facebook.github.io/react/) library for rendering out forms base
 
 This module is based on the original [react-formio](https://github.com/formio/react-formio) and add extra features listed above.
 
-See our [storybook](https://formio.tsed.io/) to see all available components.
+See our [storybook](https://formio.tsed.dev/) to see all available components.
 
 ## Features
 

--- a/packages/react-formio-stores/readme.md
+++ b/packages/react-formio-stores/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -14,11 +14,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/tutorials/prisma.html">Tutorial</a>
+  <a href="https://tsed.dev/tutorials/prisma.html">Tutorial</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://slack.tsed.dev">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>
@@ -31,7 +31,7 @@ platform.
 This module is based on the original [react-formio](https://github.com/formio/react-formio) and add extra features
 listed above.
 
-See our [storybook](https://formio.tsed.io/) to see all available components.
+See our [storybook](https://formio.tsed.dev/) to see all available components.
 
 ## Install
 

--- a/packages/react-formio/readme.md
+++ b/packages/react-formio/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -14,11 +14,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/tutorials/prisma.html">Tutorial</a>
+  <a href="https://tsed.dev/tutorials/prisma.html">Tutorial</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://slack.tsed.dev">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>
@@ -31,25 +31,25 @@ platform.
 This module is based on the original [react-formio](https://github.com/formio/react-formio) and add extra features
 listed above.
 
-See our [storybook](https://formio.tsed.io/?path=/docs/getting-started--docs) to see all available components.
+See our [storybook](https://formio.tsed.dev/?path=/docs/getting-started--docs) to see all available components.
 
 ## Features
 
 Many components are provided to build your own backoffice based on Formio.js API:
 
-- [ActionsTable](https://formio.tsed.io/?path=story/reactformio-actionstable--sandbox),
-- [FormAccess](https://formio.tsed.io/?path=story/reactformio-formaccess--sandbox),
-- [FormAction](https://formio.tsed.io/?path=story/reactformio-formaction--sandbox),
-- [Form](https://formio.tsed.io/?path=docs/documentation-form--docs),
-- [FormBuilder](https://formio.tsed.io/?path=docs/documentation-formbuilder--docs),
-- [FormEdit](https://formio.tsed.io/?path=docs/documentation-formedit--docs),
-- [FormsTable](https://formio.tsed.io/?path=docs/documentation-formstable--docs),
-- [InputTags](https://formio.tsed.io/?path=story/reactformio-inputtags--sandbox),
-- [InputText](https://formio.tsed.io/?path=story/reactformio-inputtext--sandbox),
-- [Pagination](https://formio.tsed.io/?path=story/reactformio-pagination--sandbox),
-- [Select](https://formio.tsed.io/?path=/story/reactformio-select--sandbox),
-- [SubmissionsTable](https://formio.tsed.io/?path=/docs/documentation-submissionstable--docs).
-- [Table](https://formio.tsed.io/?path=/story/reactformio-table--sandbox),
+- [ActionsTable](https://formio.tsed.dev/?path=story/reactformio-actionstable--sandbox),
+- [FormAccess](https://formio.tsed.dev/?path=story/reactformio-formaccess--sandbox),
+- [FormAction](https://formio.tsed.dev/?path=story/reactformio-formaction--sandbox),
+- [Form](https://formio.tsed.dev/?path=docs/documentation-form--docs),
+- [FormBuilder](https://formio.tsed.dev/?path=docs/documentation-formbuilder--docs),
+- [FormEdit](https://formio.tsed.dev/?path=docs/documentation-formedit--docs),
+- [FormsTable](https://formio.tsed.dev/?path=docs/documentation-formstable--docs),
+- [InputTags](https://formio.tsed.dev/?path=story/reactformio-inputtags--sandbox),
+- [InputText](https://formio.tsed.dev/?path=story/reactformio-inputtext--sandbox),
+- [Pagination](https://formio.tsed.dev/?path=story/reactformio-pagination--sandbox),
+- [Select](https://formio.tsed.dev/?path=/story/reactformio-select--sandbox),
+- [SubmissionsTable](https://formio.tsed.dev/?path=/docs/documentation-submissionstable--docs).
+- [Table](https://formio.tsed.dev/?path=/story/reactformio-table--sandbox),
 - Predefined Reducers for Actions, Action, Form, Forms, Submission, Submissions, etc...,
 - TypeScript support.
 - Tailwind support.
@@ -91,7 +91,7 @@ function App() {
 export default App;
 ```
 
-See more on http://formio.tsed.io/?path=/docs/getting-started--docs
+See more on http://formio.tsed.dev/?path=/docs/getting-started--docs
 
 ## Contributors
 

--- a/packages/redux-utils/readme.md
+++ b/packages/redux-utils/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -14,11 +14,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/tutorials/prisma.html">Tutorial</a>
+  <a href="https://tsed.dev/tutorials/prisma.html">Tutorial</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://slack.tsed.dev">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>

--- a/packages/tailwind-formio/readme.md
+++ b/packages/tailwind-formio/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -14,11 +14,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/tutorials/prisma.html">Tutorial</a>
+  <a href="https://tsed.dev/tutorials/prisma.html">Tutorial</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://slack.tsed.dev">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>

--- a/stories/FormTable.mdx
+++ b/stories/FormTable.mdx
@@ -16,7 +16,7 @@ import * as FormsTableStories from '../packages/react-formio/src/components/form
 
 # FormsTable
 
-The [FormsTable](https://formio.tsed.io/?path=/story/reactformio-formstable--sandbox) component can be used to render a
+The [FormsTable](https://formio.tsed.dev/?path=/story/reactformio-formstable--sandbox) component can be used to render a
 list of forms with buttons to edit, view, delete, etc on each row.
 
 ## Props

--- a/stories/Getting-started.mdx
+++ b/stories/Getting-started.mdx
@@ -4,8 +4,8 @@ import * as FormBuilderStories from '../packages/react-formio/src/components/for
 <Meta title="Getting started" />
 
 <div className="flex items-center justify-center pb-5">
-  <a href="https://tsed.io" target="_blank"><img className="overflow-hidden block"
-                                                 src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+  <a href="https://tsed.dev" target="_blank"><img className="overflow-hidden block"
+                                                 src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </div>
 
 <div className="text-center pb-5">
@@ -25,11 +25,11 @@ import * as FormBuilderStories from '../packages/react-formio/src/components/for
 </div>
 
 <div className="text-center pb-5">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/tutorials/prisma.html">Tutorial</a>
+  <a href="https://tsed.dev/tutorials/prisma.html">Tutorial</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://slack.tsed.dev">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>
@@ -42,7 +42,7 @@ platform.
 This module is based on the original [react-formio](https://github.com/formio/react-formio) and add extra features
 listed above.
 
-See our [storybook](https://formio.tsed.io/) to see all available components.
+See our [storybook](https://formio.tsed.dev/) to see all available components.
 
 ## Features
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation URLs to reflect the rebranding to the new domain. All reference links, including those for the logo, website, tutorials, Slack channels, and storybook resources, now point to the updated tsed.dev domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->